### PR TITLE
Remove update-nightly target from custom_rules.xml

### DIFF
--- a/Android/.gitignore
+++ b/Android/.gitignore
@@ -7,10 +7,8 @@ ant.properties
 local.properties
 proguard-project.txt
 
+# Ignore generated language modules accessible through alternate path
 assets/lang/mo
-
-# ignore property files for updating to match nightly build from ci.narc.ro
-nightly-*
 
 # Ignore keystore (used for signing release APK for Google Play)
 cddaandroid.keystore

--- a/Android/custom_rules.xml
+++ b/Android/custom_rules.xml
@@ -8,25 +8,6 @@
   </classpath>
 </taskdef>
 
-<target name="update-nightly">
-	<get dest="nightly-SHA1.xml" src="http://ci.narc.ro/job/Cataclysm-Matrix/lastBuild/api/xml?xpath=//lastBuiltRevision/SHA1" />
-	<get dest="nightly-id.xml" src="http://ci.narc.ro/job/Cataclysm-Matrix/lastBuild/api/xml?xpath=//matrixBuild/id" />
-		
-	<xmlproperty file="nightly-SHA1.xml" />
-	<xmlproperty file="nightly-id.xml" />
-	<propertyregex property="SHA1-8"
-        input="${SHA1}"
-        regexp="^(.{8}).*"
-        replace="\1"/>
-	
-	<exec executable="git" failonerror="true">
-		<arg line="fetch https://github.com/CleverRaven/Cataclysm-DDA.git" />
-	</exec>
-	<exec executable="git" failonerror="true">
-		<arg line="checkout -B update-${id}-${SHA1-8} ${SHA1}"/>
-	</exec>
-</target>
-
 <target name="-pre-build">
     <condition property="cdda.flags" value="APP_CFLAGS+=&quot;-DRELEASE=1 -O3&quot; APP_CPPFLAGS+=&quot;-std=c++11&quot;" else="APP_CFLAGS+=&quot;&quot;">
         <equals  arg1="${build.is.packaging.debug}" arg2="false" trim="true" /> 


### PR DESCRIPTION
Jenkins like to spit out useless binary files in place of well-formed xml when he feels like it.