### PR TITLE
Switch c++ shared

### DIFF
--- a/Android/jni/Application.mk
+++ b/Android/jni/Application.mk
@@ -1,8 +1,9 @@
 # Reference: https://developer.android.com/ndk/guides/application_mk.html
 
 # See CPLUSPLUS-SUPPORT.html in the NDK documentation for more information
-APP_STL := gnustl_shared
+APP_STL := c++_shared
 APP_CPPFLAGS += -std=c++11
+APP_LDFLAGS += -fuse-ld=gold
 
 # armeabi-v7a covers 98.5%, x86 is 1.5%, armeabi is 0%
 # See http://hwstats.unity3d.com/mobile/cpu.html

--- a/Android/jni/libintl-lite/internal/libintl.cpp
+++ b/Android/jni/libintl-lite/internal/libintl.cpp
@@ -334,6 +334,6 @@ libintl_lite_bool_t bindtextdomain(const char* domain, const char* moFilePath)
 
 libintl_lite_bool_t bind_textdomain_codeset(const char* domain, const char* oFilePath)
 {
-	// not implemented yet
+	return LIBINTL_LITE_BOOL_FALSE;
 }
 #endif

--- a/Android/src/org/libsdl/app/SDLActivity.java
+++ b/Android/src/org/libsdl/app/SDLActivity.java
@@ -71,7 +71,7 @@ public class SDLActivity extends Activity {
      */
     protected String[] getLibraries() {
         return new String[] {
-            "gnustl_shared",
+            "c++_shared",
             "SDL2",
             "SDL2_image",
             "SDL2_mixer",

--- a/src/catacharset.cpp
+++ b/src/catacharset.cpp
@@ -427,15 +427,9 @@ std::wstring utf8_to_wstr( const std::string &str )
     strip_trailing_nulls( wstr );
     return wstr;
 #else
-#ifndef __ANDROID__
     std::size_t sz = std::mbstowcs( NULL, str.c_str(), str.size() );
     std::wstring wstr( sz, '\0' );
     std::mbstowcs( &wstr[0], str.c_str(), sz );
-#else
-    std::size_t sz = mbstowcs( NULL, str.c_str(), str.size() );
-    std::wstring wstr( sz, '\0' );
-    mbstowcs( &wstr[0], str.c_str(), sz );
-#endif
     strip_trailing_nulls( wstr );
     return wstr;
 #endif

--- a/src/harvest.cpp
+++ b/src/harvest.cpp
@@ -144,13 +144,8 @@ std::string harvest_list::describe( int at_skill ) const
             max_f = en.max;
         }
         // @todo Avoid repetition here by making a common harvest drop function
-#ifdef __ANDROID__
-        int max_drops = std::min<int>( en.max, round( std::max( 0.0f, max_f ) ) );
-        int min_drops = std::max<int>( 0.0f, round( std::min( min_f, max_f ) ) );
-#else
         int max_drops = std::min<int>( en.max, std::round( std::max( 0.0f, max_f ) ) );
         int min_drops = std::max<int>( 0.0f, std::round( std::min( min_f, max_f ) ) );
-#endif
         if( max_drops <= 0 ) {
             return std::string();
         }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1167,9 +1167,6 @@ void options_manager::init()
 
     add("ANIMATION_DELAY", "graphics", _("Animation delay"),
         _("The amount of time to pause between animation frames in ms."),
-#ifdef __ANDROID__
-        0, 300, 150
-#else
         0, 100, 10
 #endif
         );
@@ -1238,7 +1235,7 @@ void options_manager::init()
         0, 10000, 0, COPT_CURSES_HIDE
         );
 
-#ifndef __ANDROID__
+#ifndef __ANDROID__ // Android is always fullscreen
     optionNames["fullscreen"] = _("Fullscreen");
     optionNames["windowedbl"] = _("Windowed borderless");
     add("FULLSCREEN", "graphics", _("Fullscreen"),
@@ -1249,7 +1246,7 @@ void options_manager::init()
     
     add("SOFTWARE_RENDERING", "graphics", _("Software rendering"),
         _("Use software renderer instead of graphics card acceleration."),
-#ifdef __ANDROID__
+#ifdef __ANDROID__ // Android performs much better with software rendering
         true, COPT_CURSES_HIDE
 #else
         false, COPT_CURSES_HIDE

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1577,7 +1577,7 @@ std::string rewrite_vsnprintf( const char *msg )
     return rewritten_msg.str();
 }
 
-#ifdef __ANDROID__
+#ifdef __ANDROID__ // TODO: Check if this is why -fsigned-char breaks localization
 std::string vstring_format_internal( char const *format, va_list args );
 #endif
 std::string vstring_format( char const *format, va_list args )

--- a/src/profession.cpp
+++ b/src/profession.cpp
@@ -584,11 +584,7 @@ std::vector<item> json_item_substitution::get_substitution( const item &it,
     const long old_amt = it.count_by_charges() ? it.charges : 1l;
     for( const substitution::info &inf : sub->infos ) {
         item result( inf.new_item );
-#ifdef __ANDROID__
-        const long new_amt = std::max( 1l, ( long )round( inf.ratio * old_amt ) );
-#else
         const long new_amt = std::max( 1l, ( long )std::round( inf.ratio * old_amt ) );
-#endif
 
         if( !result.count_by_charges() ) {
             for( long i = 0; i < new_amt; i++ ) {

--- a/src/ranged.cpp
+++ b/src/ranged.cpp
@@ -1100,11 +1100,7 @@ double Creature::projectile_attack_chance( double dispersion, double range, doub
     // erf(x / (sigma * sqrt(2))) is the probability that a measurement
     // of a normally distributed variable with standard deviation sigma
     // lies in the range [-x..x]
-#ifdef __ANDROID__
-    return erf( shot_dispersion / ( sigma * sqrt2 ) );
-#else
     return std::erf( shot_dispersion / ( sigma * sqrt2 ) );
-#endif
 }
 
 static int print_ranged_chance( const player &p, WINDOW *w, int line_number,

--- a/src/rng.cpp
+++ b/src/rng.cpp
@@ -114,11 +114,7 @@ double erfinv( double x )
     // d/dz ( erf(z) - x ) = 2/sqrt(pi) . e^(-z^2)
 
     for( int n = 0; n < 50; ++n ) {
-#ifdef __ANDROID__
-        double step = ( erf( z ) - x ) / ( m_2_sqrtpi * exp( -z * z ) );
-#else
         double step = ( std::erf( z ) - x ) / ( m_2_sqrtpi * exp( -z * z ) );
-#endif
         z -= step;
         if( std::abs( step ) < epsilon ) {
             break;

--- a/src/sdltiles.cpp
+++ b/src/sdltiles.cpp
@@ -338,9 +338,6 @@ bool WinCreate()
 
 #ifndef __ANDROID__
     if (get_option<std::string>( "FULLSCREEN" ) == "fullscreen") {
-#endif
-        window_flags |= SDL_WINDOW_FULLSCREEN;
-#ifndef __ANDROID__
     } else if (get_option<std::string>( "FULLSCREEN" ) == "windowedbl") {
         window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
         SDL_SetHint(SDL_HINT_VIDEO_MINIMIZE_ON_FOCUS_LOSS, "0");
@@ -359,6 +356,7 @@ bool WinCreate()
     SDL_GL_SetAttribute(SDL_GL_GREEN_SIZE, 6); 
     SDL_GL_SetAttribute(SDL_GL_BLUE_SIZE, 5); 
 
+    // Prevent mouse|touch input confusion
     SDL_SetHint(SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, "1");
 #endif
 


### PR DESCRIPTION
This fixes the incomplete c++11 std namespace issue with using the gnustl library. And it's going ot be absolutely needed to continue pulling mainline, as the current mainline codebase will break gnustl functionality outright. The gnustl library is deprecated for Android(along with GCC), according to Google.